### PR TITLE
1st two matches from 2021 "base-space tournament"

### DIFF
--- a/data/openings.csv
+++ b/data/openings.csv
@@ -30,3 +30,9 @@ game_id,hypothetical,player,opening_type,opening,kingdom
 5975251,1,1,4-3,Militia-Chapel,Chapel-Harbinger-Village-Workshop-Militia-Moneylender-Poacher-Council Room-Festival-Market
 6193342,1,2,5-2,Sentry-,Harbinger-Workshop-Bureaucrat-Militia-Poacher-Council Room-Laboratory-Library-Market-Sentry
 6227420,1,2,5-2,Sentry-,Merchant-Gardens-Militia-Moneylender-Remodel-Throne Room-Bandit-Festival-Laboratory-Sentry
+70580237,0,1,3-4,Silver-Militia,Cellar-Moat-Vassal-Village-Militia-Poacher-Festival-Library-Sentry-Witch
+70580237,0,1,2-5,Chapel-Laboratory,Chapel-Moat-Workshop-Bureaucrat-Moneylender-Poacher-Throne Room-Bandit-Laboratory-Witch
+70582512,0,2,4-3,Chapel-Vassal,Chapel-Harbinger-Vassal-Throne Room-Laboratory-Market-Mine-Sentry-Witch-Artisan
+71112172,0,1,3-4,Vassal-Poacher,Vassal-Village-Bureaucrat-Poacher-Smithy-Throne Room-Council Room-Festival-Library-Sentry
+71113715,0,2,4-3,Poacher-Chapel,Cellar-Chapel-Merchant-Vassal-Village-Poacher-Bandit-Laboratory-Market
+71115823,0,2,3-4,Silver-Militia,Moat-Merchant-Vassal-Workshop-Gardens-Militia-Library-Market-Sentry-Artisan

--- a/data/openings.csv
+++ b/data/openings.csv
@@ -31,8 +31,14 @@ game_id,hypothetical,player,opening_type,opening,kingdom
 6193342,1,2,5-2,Sentry-,Harbinger-Workshop-Bureaucrat-Militia-Poacher-Council Room-Laboratory-Library-Market-Sentry
 6227420,1,2,5-2,Sentry-,Merchant-Gardens-Militia-Moneylender-Remodel-Throne Room-Bandit-Festival-Laboratory-Sentry
 70580237,0,1,3-4,Silver-Militia,Cellar-Moat-Vassal-Village-Militia-Poacher-Festival-Library-Sentry-Witch
-70580237,0,1,2-5,Chapel-Laboratory,Chapel-Moat-Workshop-Bureaucrat-Moneylender-Poacher-Throne Room-Bandit-Laboratory-Witch
+70580796,0,1,2-5,Chapel-Laboratory,Chapel-Moat-Workshop-Bureaucrat-Moneylender-Poacher-Throne Room-Bandit-Laboratory-Witch
+70581749,0,1,4-3,Moneylender-Silver,Moat-Vassal-Militia-Moneylender-Poacher-Remodel-Council Room-Festival-Market-Mine
 70582512,0,2,4-3,Chapel-Vassal,Chapel-Harbinger-Vassal-Throne Room-Laboratory-Market-Mine-Sentry-Witch-Artisan
 71112172,0,1,3-4,Vassal-Poacher,Vassal-Village-Bureaucrat-Poacher-Smithy-Throne Room-Council Room-Festival-Library-Sentry
 71113715,0,2,4-3,Poacher-Chapel,Cellar-Chapel-Merchant-Vassal-Village-Poacher-Bandit-Laboratory-Market
+71114568,0,1,4-3,Militia-Chapel,Cellar-Chapel-Moat-Village-Gardens-Militia-Moneylender-Smithy-Laboratory-Sentry
 71115823,0,2,3-4,Silver-Militia,Moat-Merchant-Vassal-Workshop-Gardens-Militia-Library-Market-Sentry-Artisan
+71933307,0,1,5-2,Bandit-Chapel,Cellar-Chapel-Merchant-Vassal-Moneylender-Smithy-Bandit-Council Room-Laboratory-Library
+71934132,0,2,5-2,Workshop-Moat,Chapel-Moat-Merchant-Village-Workshop-Bureaucrat-Gardens-Poacher-Smithy-Library-Mine
+71934929,0,1,3-4,Chapel-Militia,Chapel-Harbinger-Militia-Moneylender-Poacher-Remodel-Council Room-Laboratory-Library-Market
+71935274,0,1,3-4,Chapel-Poacher,Chapel-Harbinger-Merchant-Gardens-Poacher-Smithy-Bandit-Laboratory-Market-Witch

--- a/data/openings.csv
+++ b/data/openings.csv
@@ -31,14 +31,14 @@ game_id,hypothetical,player,opening_type,opening,kingdom
 6193342,1,2,5-2,Sentry-,Harbinger-Workshop-Bureaucrat-Militia-Poacher-Council Room-Laboratory-Library-Market-Sentry
 6227420,1,2,5-2,Sentry-,Merchant-Gardens-Militia-Moneylender-Remodel-Throne Room-Bandit-Festival-Laboratory-Sentry
 70580237,0,1,3-4,Silver-Militia,Cellar-Moat-Vassal-Village-Militia-Poacher-Festival-Library-Sentry-Witch
-70580796,0,1,2-5,Chapel-Laboratory,Chapel-Moat-Workshop-Bureaucrat-Moneylender-Poacher-Throne Room-Bandit-Laboratory-Witch
+70580796,0,2,2-5,Chapel-Laboratory,Chapel-Moat-Workshop-Bureaucrat-Moneylender-Poacher-Throne Room-Bandit-Laboratory-Witch
 70581749,0,1,4-3,Moneylender-Silver,Moat-Vassal-Militia-Moneylender-Poacher-Remodel-Council Room-Festival-Market-Mine
 70582512,0,2,4-3,Chapel-Vassal,Chapel-Harbinger-Vassal-Throne Room-Laboratory-Market-Mine-Sentry-Witch-Artisan
 71112172,0,1,3-4,Vassal-Poacher,Vassal-Village-Bureaucrat-Poacher-Smithy-Throne Room-Council Room-Festival-Library-Sentry
-71113715,0,2,4-3,Poacher-Chapel,Cellar-Chapel-Merchant-Vassal-Village-Poacher-Bandit-Laboratory-Market
-71114568,0,1,4-3,Militia-Chapel,Cellar-Chapel-Moat-Village-Gardens-Militia-Moneylender-Smithy-Laboratory-Sentry
+71113715,0,2,4-3,Poacher-Chapel,Cellar-Chapel-Merchant-Vassal-Village-Poacher-Bandit-Laboratory-Market-Artisan
+71114568,0,1,4-3,Militia-Chapel,Cellar-Chapel-Moat-Village-Gardens-Militia-Moneylender-Smithy-Laboratory-Library
 71115823,0,2,3-4,Silver-Militia,Moat-Merchant-Vassal-Workshop-Gardens-Militia-Library-Market-Sentry-Artisan
 71933307,0,1,5-2,Bandit-Chapel,Cellar-Chapel-Merchant-Vassal-Moneylender-Smithy-Bandit-Council Room-Laboratory-Library
-71934132,0,2,5-2,Workshop-Moat,Chapel-Moat-Merchant-Village-Workshop-Bureaucrat-Gardens-Poacher-Smithy-Library-Mine
+71934132,0,2,5-2,Workshop-Moat,Chapel-Moat-Merchant-Workshop-Bureaucrat-Gardens-Poacher-Smithy-Library-Mine
 71934929,0,1,3-4,Chapel-Militia,Chapel-Harbinger-Militia-Moneylender-Poacher-Remodel-Council Room-Laboratory-Library-Market
-71935274,0,1,3-4,Chapel-Poacher,Chapel-Harbinger-Merchant-Gardens-Poacher-Smithy-Bandit-Laboratory-Market-Witch
+71935274,0,2,3-4,Chapel-Poacher,Chapel-Harbinger-Merchant-Gardens-Poacher-Smithy-Bandit-Laboratory-Market-Witch


### PR DESCRIPTION
Add Burning Skull's openings from his first two matches in the 2021 "Dominion base-space tournament".  Sources:
- Burning Skull, [Dominion base-space tournament vs amoffett11](https://www.youtube.com/watch?v=DorVPvPQQxY), *YouTube* (2021-03-28)
- Burning Skull, [Dominion base-space tournament vs JaCrispyKing](https://www.youtube.com/watch?v=rgmGwpqKpYs), *YouTube* (2021-04-04)